### PR TITLE
fix build on Ruby 3

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -9,14 +9,18 @@ if have_header('termios.h') &&
   have_header('sys/ioctl.h')
 
   if RUBY_VERSION >= '1.7'
-    have_header('ruby/io.h')
-    if have_type("rb_io_t", ["ruby.h", "rubyio.h"])
-      have_struct_member("rb_io_t", "fd", ["ruby.h", "rubyio.h"])
+    if have_header('ruby/io.h')
+      have_type("rb_io_t", ["ruby/io.h"])
+      have_struct_member("rb_io_t", "fd", ["ruby/io.h"])
     else
-      have_struct_member("OpenFile", "fd", ["ruby.h", "rubyio.h"])
-    end
-    if have_macro("OpenFile", ["ruby.h", "rubyio.h"])
-      $defs.push("-DHAVE_MACRO_OPENFILE")
+      if have_type("rb_io_t", ["ruby.h", "rubyio.h"])
+        have_struct_member("rb_io_t", "fd", ["ruby.h", "rubyio.h"])
+      else
+        have_struct_member("OpenFile", "fd", ["ruby.h", "rubyio.h"])
+      end
+      if have_macro("OpenFile", ["ruby.h", "rubyio.h"])
+        $defs.push("-DHAVE_MACRO_OPENFILE")
+      end
     end
   end
 


### PR DESCRIPTION
Hi,

This gem doesn't build on Ruby 3.  If I try to build on Ruby 3.0, I get the following errors:

```
../../../../ext/termios.c:311:5: error: use of undeclared identifier 'OpenFile'
    OpenFile *fptr;
    ^
../../../../ext/termios.c:311:15: error: use of undeclared identifier 'fptr'
    OpenFile *fptr;
              ^
../../../../ext/termios.c:314:21: error: use of undeclared identifier 'fptr'
    GetOpenFile(io, fptr);
                    ^
```

The patch in this PR makes the gem build again.

Thanks!